### PR TITLE
fix IT to use empty ctx root

### DIFF
--- a/src/test/java/org/eclipse/microprofile/system/test/app/AppContainerConfig.java
+++ b/src/test/java/org/eclipse/microprofile/system/test/app/AppContainerConfig.java
@@ -25,13 +25,13 @@ import org.testcontainers.junit.jupiter.Container;
 
 public class AppContainerConfig implements SharedContainerConfiguration {
 
-	@Container
-	public static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>()
-					.withNetworkAliases("testpostgres")
-					.withDatabaseName("test")
-					.withExposedPorts(5432)
-					.withInitScript("init.sql");
-	
+    @Container
+    public static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>()
+                    .withNetworkAliases("testpostgres")
+                    .withDatabaseName("test")
+                    .withExposedPorts(5432)
+                    .withInitScript("init.sql");
+    
     @Container
     public static MicroProfileApplication app = new MicroProfileApplication()
                     .withEnv("POSTGRES_HOSTNAME", "testpostgres")
@@ -39,7 +39,7 @@ public class AppContainerConfig implements SharedContainerConfiguration {
                     .withEnv("boost_db_databaseName", "test")
                     .withEnv("boost_db_username", "test")
                     .withEnv("boost_db_password", "test")
-                    .withAppContextRoot("/myservice");
+                    .withAppContextRoot("");
     
     @Override
     public void startContainers() {


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

**Note:**  This won't work until the current boost master is released as 0.2.    (Or one could use 0.2-SNAPSHOT and build the current boost master locally).